### PR TITLE
fix: Prevent MoaType registry corruption due to egg itemstack mutation

### DIFF
--- a/src/main/java/com/aetherteam/aether/api/registers/MoaType.java
+++ b/src/main/java/com/aetherteam/aether/api/registers/MoaType.java
@@ -18,4 +18,6 @@ public record MoaType(ItemStack egg, int maxJumps, float speed, int spawnChance,
             ResourceLocation.CODEC.fieldOf("saddle_texture").forGetter(MoaType::saddleTexture),
             ResourceLocation.CODEC.optionalFieldOf("jumps_texture").forGetter(MoaType::jumpsTexture)
         ).apply(in, MoaType::new));
+
+    public ItemStack egg() { return this.egg.copy(); }
 }


### PR DESCRIPTION
The MoaType record stores the type of egg a Moa should lay as an ItemStack. Any egg laid by a Moa is thus an instance of the ItemStack held within the registry. This introduces problems due to the fact that the ItemStack remains mutable while in the registry. It is possible in various ways to corrupt the MoaType registry by causing the recorded egg ItemStack to be reduced to 0 items thus transforming it into air. One easily replicable way to do this is when two laid Moa eggs merge into a single ItemEntity, which causes one of them to reduce its held ItemStack to 0 and replace it with air to delete it. That action sets the ItemStack within the record to 0 as well.

The occurrence of this bug will break Moa behavior for the rest of the server uptime until it is restarted and the registry is rebuilt. At best, the error will cause Moas to lay nothing but air. At worst, it prevents clients from joining the server due to the MoaType registry failing to serialize since the ItemStack being serialized is not allowed to be air; they will be infinitely stuck on a "Joining World" screen waiting for a packet that never arrives. (I have only been able to replicate the serialization failure on a larger modpack, but the egg laying behavior breaking happens with just the Aether installed.)

The solution I've used is to modify the MoaType egg accessor to always return a copy of the egg ItemStack instead of the ItemStack stored in the registry. This new copy is free to be mutated in any way without touching the original in the registry. I have confirmed on my own server instance that this change resolves the bug, and as far as I can tell it has no side effects.

Closes issue #2770

Please let me know if you have any concerns.

---

I agree to the Contributor License Agreement (CLA).